### PR TITLE
Allow custom path

### DIFF
--- a/src/Ae.Dns.Client/DnsHttpClient.cs
+++ b/src/Ae.Dns.Client/DnsHttpClient.cs
@@ -37,7 +37,7 @@ namespace Ae.Dns.Client
 #endif
             content.Headers.ContentType = new MediaTypeHeaderValue(DnsMessageType);
 
-            using var request = new HttpRequestMessage(HttpMethod.Post, "/dns-query") { Content = content };
+            using var request = new HttpRequestMessage(HttpMethod.Post, _httpClient.BaseAddress.AbsolutePath.Any() ? _httpClient.BaseAddress.AbsolutePath : "/dns-query") { Content = content };
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(DnsMessageType));
 
             using var response = await _httpClient.SendAsync(request, token);


### PR DESCRIPTION
Some DoH providers use different path to customize filtering options or add metadata for logging. For example, [ControlD](https://controld.com/free-dns) use `https://freedns.controld.com/p2` for ad filtering. Instead of always using `/dns-query` for the path, this change checks if the BaseAddress already has a non-empty path and uses it instead.

Without this change, using ControlD, for example, will always return a non-filtering endpoint (eg, regardless of using the adblocking or family-friendly address, ad & adult server will not be blocked), and NextDNS endpoint will not apply the profile's custom filtering.