### PR TITLE
Implements Grouped Racer Client

### DIFF
--- a/misc/Ae.Dns.Console/DnsConfiguration.cs
+++ b/misc/Ae.Dns.Console/DnsConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Ae.Dns.Console
 {
@@ -15,5 +16,6 @@ namespace Ae.Dns.Console
         public string? DhcpdConfigFile { get; set; }
         public string? DhcpdLeasesHostnameSuffix { get; set; }
         public DnsInfluxDbConfiguration? InfluxDbMetrics { get; set; }
+        public Dictionary<string, string[]> ClientGroups { get; set; } = new Dictionary<string, string[]>();
     }
 }

--- a/misc/Ae.Dns.Console/config.json
+++ b/misc/Ae.Dns.Console/config.json
@@ -1,31 +1,53 @@
 {
-    "serilog": {
-        "using": [ "Serilog.Sinks.Console" ],
-        "writeTo": [
-            { "name": "Console" }
-        ]
-        // Change level: "minimumLevel": "Warning"
-    },
-    "httpsUpstreams": [
-        "https://dns.google/",
-        "https://cloudflare-dns.com/",
-        "https://doh.opendns.com/"
-    ],
-    "remoteBlocklists": [
-        // Examples:
-        // * https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
-        // * https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
-        // A remote hosts file or simply a list of domain names
-    ],
-    "disallowedDomainSuffixes": [
-        // Adding example.org here means *.example.org is blocked
-    ],
-    "allowlistedDomains": [
-        // Adding google.com means google.com is explicitly allowed regardless of the blocklists
-        // It doesn't mean *.google.com is allowed, this is an exact match only
-    ],
-    "hostFiles": [
-        // Host files to monitor for changes and incorporate into DNS lookups
-        // For example: "C:\\Windows\\System32\\drivers\\etc\\hosts"
+  "serilog": {
+    "using": [ "Serilog.Sinks.Console" ],
+    "writeTo": [
+      { "name": "Console" }
     ]
+    // Change level: "minimumLevel": "Warning"
+  },
+  "httpsUpstreams": [
+    "https://8.8.8.8/",
+    "https://8.8.4.4/",
+    "https://1.1.1.1/",
+    "https://1.0.0.1/",
+    "https://146.112.41.2/",
+    "https://208.67.222.222/",
+    "https://208.67.220.220/"
+  ],
+  "remoteBlocklists": [
+    // Examples:
+    // * https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+    // * https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
+    // A remote hosts file or simply a list of domain names
+  ],
+  "disallowedDomainSuffixes": [
+    // Adding example.org here means *.example.org is blocked
+  ],
+  "allowlistedDomains": [
+    // Adding google.com means google.com is explicitly allowed regardless of the blocklists
+    // It doesn't mean *.google.com is allowed, this is an exact match only
+  ],
+  "hostFiles": [
+    // Host files to monitor for changes and incorporate into DNS lookups
+    // For example: "C:\\Windows\\System32\\drivers\\etc\\hosts"
+  ],
+  "clientGroups": {
+    // When racing each upstream, pick one client from each group
+    // for redundancy. Optional section - if omitted, clients are
+    // not grouped and queries may be raced against the same provider.
+    "Google": [
+      "https://8.8.8.8/",
+      "https://8.8.4.4/"
+    ],
+    "CloudFlare": [
+      "https://1.1.1.1/",
+      "https://1.0.0.1/"
+    ],
+    "OpenDNS": [
+      "https://146.112.41.2/",
+      "https://208.67.222.222/",
+      "https://208.67.220.220/"
+    ]
+  }
 }

--- a/src/Ae.Dns.Client/DnsGroupRacerClient.cs
+++ b/src/Ae.Dns.Client/DnsGroupRacerClient.cs
@@ -1,0 +1,80 @@
+﻿using Ae.Dns.Client.Internal;
+using Ae.Dns.Protocol;
+using Ae.Dns.Protocol.Enums;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ae.Dns.Client
+{
+    /// <summary>
+    /// A client consisting of multiple <see cref="IDnsClient"/> instances.
+    /// At query time, two clients are picked at random, and the DNS requests race against each other.
+    /// The first non-exceptional result is used, the slower result is discarded.
+    /// </summary>
+    public sealed class DnsGroupRacerClient : IDnsClient
+    {
+        private readonly ILogger<DnsGroupRacerClient> _logger;
+        private readonly DnsGroupRacerClientOptions _options;
+
+        /// <summary>
+        /// Create a new racer DNS client using the specified <see cref="IDnsClient"/> instances to delegate to.
+        /// </summary>
+        /// <param name="logger">The logger instance to use.</param>
+        /// <param name="options">The options for this racer client.</param>
+        [ActivatorUtilitiesConstructor]
+        public DnsGroupRacerClient(ILogger<DnsGroupRacerClient> logger, IOptions<DnsGroupRacerClientOptions> options)
+        {
+            _logger = logger;
+            _options = options.Value;
+        }
+
+        /// <inheritdoc/>
+        public async Task<DnsMessage> Query(DnsMessage query, CancellationToken token)
+        {
+            var sw = Stopwatch.StartNew();
+
+            // Pick the specified number of random groups
+            var randomisedGroups = _options.DnsClientGroups.Where(x => x.Value.Count > 0).OrderBy(x => Guid.NewGuid()).Take(_options.RandomGroupQueries);
+
+            // Randomise a client from each group
+            var randomisedClients = randomisedGroups.Select(x => x.Value.OrderBy(y => Guid.NewGuid()).First());
+
+            // Start the query tasks (and create a lookup from query to client)
+            var queries = randomisedClients.ToDictionary(client => client.Query(query, token), client => client);
+
+            // Select a winning task
+            var winningTask = await TaskRacer.RaceTasks(queries.Select(x => x.Key), async result => result.IsFaulted || (await result).Header.ResponseCode == DnsResponseCode.ServFail);
+
+            // If tasks faulted, log the reason
+            var faultedTasks = queries.Keys.Where(x => x.IsFaulted).ToArray();
+            if (faultedTasks.Any())
+            {
+                var faultedClients = string.Join(", ", faultedTasks.Select(x => queries[x]));
+                if (winningTask.IsFaulted)
+                {
+                    _logger.LogError("All tasks using {FaultedClients} failed for query {Query} in {ElapsedMilliseconds}ms", faultedClients, query, sw.ElapsedMilliseconds);
+                }
+                else
+                {
+                    _logger.LogWarning("Tasks for clients {FaultedClients} failed for query {Query}, swapped with result for {SuccessfulClient} in {ElapsedMilliseconds}ms", faultedClients, query, queries[winningTask], sw.ElapsedMilliseconds);
+                }
+            }
+
+            // Await the winning task (if it's faulted, it will throw at this point)
+            var winningAnswer = await winningTask;
+            _logger.LogInformation("Winning client was {WinningClient} for query {Query} in {ElapsedMilliseconds}ms", queries[winningTask], query, sw.ElapsedMilliseconds);
+            return winningAnswer;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Ae.Dns.Client/DnsGroupRacerClient.cs
+++ b/src/Ae.Dns.Client/DnsGroupRacerClient.cs
@@ -1,6 +1,5 @@
 ﻿using Ae.Dns.Client.Internal;
 using Ae.Dns.Protocol;
-using Ae.Dns.Protocol.Enums;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -49,7 +48,7 @@ namespace Ae.Dns.Client
             var queries = randomisedClients.ToDictionary(client => client.Query(query, token), client => client);
 
             // Select a winning task
-            var winningTask = await TaskRacer.RaceTasks(queries.Select(x => x.Key), async result => result.IsFaulted || (await result).Header.ResponseCode == DnsResponseCode.ServFail);
+            var winningTask = await TaskRacer.RaceTasks(queries.Select(x => x.Key), async result => result.IsFaulted || (await result).EncounteredResolverError());
 
             // If tasks faulted, log the reason
             var faultedTasks = queries.Keys.Where(x => x.IsFaulted).ToArray();

--- a/src/Ae.Dns.Client/DnsGroupRacerClientOptions.cs
+++ b/src/Ae.Dns.Client/DnsGroupRacerClientOptions.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Ae.Dns.Protocol;
+
+namespace Ae.Dns.Client
+{
+    /// <summary>
+    /// The options for <see cref="DnsRacerClient"/>.
+    /// </summary>
+    public sealed class DnsGroupRacerClientOptions
+    {
+        /// <summary>
+        /// The number of groups from which to randomly select a client for queries.
+        /// If a fewer number of groups are supplied to the <see cref="DnsGroupRacerClientOptions"/>, 
+        /// all groups will start queries.
+        /// </summary>
+        public int RandomGroupQueries { get; set; } = 2;
+
+        /// <summary>
+        /// A dictionary of DNS clients grouped by an arbitrary identifier.
+        /// This can be used to group DNS clients of the same provider, for example.
+        /// </summary>
+        public IReadOnlyDictionary<string, IReadOnlyList<IDnsClient>> DnsClientGroups { get; set; } = new Dictionary<string, IReadOnlyList<IDnsClient>>();
+    }
+}

--- a/src/Ae.Dns.Protocol/DnsMessageExtensions.cs
+++ b/src/Ae.Dns.Protocol/DnsMessageExtensions.cs
@@ -44,6 +44,23 @@ namespace Ae.Dns.Protocol
             return null;
         }
 
+        /// <summary>
+        /// Returns true if the resolver encountered an error.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        public static bool EncounteredResolverError(this DnsMessage message)
+        {
+            if (!message.Header.IsQueryResponse)
+            {
+                return false;
+            }
+
+            return message.Header.ResponseCode == DnsResponseCode.ServFail ||
+                   message.Header.ResponseCode == DnsResponseCode.NotImp ||
+                   message.Header.ResponseCode == DnsResponseCode.NotAuth;
+        }
+
         public static bool TryParseIpAddressFromReverseLookup(this DnsMessage message, out IPAddress? address)
         {
             if (message.Header.QueryType == DnsQueryType.PTR && message.Header.Host.Count > 3


### PR DESCRIPTION
Adds support for grouping clients when racing them, to allow racing DNS queries from different DNS providers to provide redundancy.